### PR TITLE
fix(ci): pin pnpm via packageManager to stop lockfile drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # pnpm version comes from package.json "packageManager" so the
+      # lockfile and CI can never drift (a floating "latest" broke
+      # --frozen-lockfile when pnpm 11 changed lockfile normalization).
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -52,9 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # pnpm version comes from package.json "packageManager" so the
+      # lockfile and CI can never drift (a floating "latest" broke
+      # --frozen-lockfile when pnpm 11 changed lockfile normalization).
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/package.json
+++ b/package.json
@@ -63,5 +63,6 @@
       "minimatch": ">=10.2.1",
       "lodash": ">=4.17.23"
     }
-  }
+  },
+  "packageManager": "pnpm@10.34.4"
 }


### PR DESCRIPTION
The Build check has been red on `main` since ~June 29 with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — it also blocked Dependabot's vite/js-yaml security updates and is currently blocking Renovate's astro vulnerability fix.

**Root cause:** `pnpm/action-setup` used `version: latest`. pnpm 11.10.0 shipped and normalizes `overrides` differently, so `--frozen-lockfile` rejects the (perfectly valid) pnpm-10 lockfile. No repo change was involved — pure toolchain drift.

**Fix:** pin `"packageManager": "pnpm@10.34.4"` in package.json and drop `version: latest` from both action-setup steps (the action reads `packageManager` when no version is given). Verified locally that the lockfile is byte-identical under pnpm 10.34.4. Renovate will now propose pnpm upgrades (including the 11 major) as ordinary reviewable PRs instead of them arriving as silent CI breakage.

Once green and merged, Renovate's `npm-astro-vulnerability` PR should go green on rebase and auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015poiKu38K88t2iBCX9AFpc

---
_Generated by [Claude Code](https://claude.ai/code/session_015poiKu38K88t2iBCX9AFpc)_